### PR TITLE
Add fallback for X-Goog-Visitor-Id header

### DIFF
--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -122,7 +122,7 @@ export default class YTMusic {
 		const headers: Record<string, any> = {
 			...this.client.defaults.headers,
 			"x-origin": this.client.defaults.baseURL,
-			"X-Goog-Visitor-Id": this.config.VISITOR_DATA,
+			"X-Goog-Visitor-Id": this.config.VISITOR_DATA || '',
 			"X-YouTube-Client-Name": this.config.INNERTUBE_CONTEXT_CLIENT_NAME,
 			"X-YouTube-Client-Version": this.config.INNERTUBE_CLIENT_VERSION,
 			"X-YouTube-Device": this.config.DEVICE,


### PR DESCRIPTION
Fixes #5

Okay, I apparently fixed it quite easily by adding a fallback to the `X-Goog-Visitor-Id` header.

Hope this helps :)