### PR TITLE
Feature: Add featured on playlists and similar artists parsers

### DIFF
--- a/src/parsers/ArtistParser.ts
+++ b/src/parsers/ArtistParser.ts
@@ -5,6 +5,7 @@ import traverseString from "../utils/traverseString"
 import AlbumParser from "./AlbumParser"
 import SongParser from "./SongParser"
 import VideoParser from "./VideoParser"
+import PlaylistParser from "./PlaylistParser";
 
 export default class ArtistParser {
 	public static parse(data: any, artistId: string): ArtistFull {
@@ -42,6 +43,18 @@ export default class ArtistParser {
 						?.contents.map((item: any) =>
 							VideoParser.parseArtistTopVideo(item, artistBasic),
 						) ?? [],
+				featuredOn:
+					traverseList(data, "musicCarouselShelfRenderer")
+						?.at(3)
+						?.contents.map((item: any) =>
+							PlaylistParser.parseArtistFeaturedOn(item),
+						) ?? [],
+				similarArtists:
+					traverseList(data, "musicCarouselShelfRenderer")
+						?.at(4)
+						?.contents.map((item: any) =>
+                        	this.parseSimilarArtists(item),
+					) ?? [],
 			},
 			ArtistFull,
 		)
@@ -55,6 +68,18 @@ export default class ArtistParser {
 				type: "ARTIST",
 				artistId: traverseString(item, "browseId")(),
 				name: traverseString(flexColumns[0], "runs", "text")(),
+				thumbnails: traverseList(item, "thumbnails"),
+			},
+			ArtistDetailed,
+		)
+	}
+
+	public static parseSimilarArtists(item: any): ArtistDetailed {
+		return checkType(
+			{
+				type: "ARTIST",
+				artistId: traverseString(item, "browseId")(),
+				name: traverseString(item, "runs", "text")(),
 				thumbnails: traverseList(item, "thumbnails"),
 			},
 			ArtistDetailed,

--- a/src/parsers/ArtistParser.ts
+++ b/src/parsers/ArtistParser.ts
@@ -54,7 +54,7 @@ export default class ArtistParser {
 						?.at(4)
 						?.contents.map((item: any) =>
                         	this.parseSimilarArtists(item),
-					) ?? [],
+						) ?? [],
 			},
 			ArtistFull,
 		)

--- a/src/parsers/PlaylistParser.ts
+++ b/src/parsers/PlaylistParser.ts
@@ -43,4 +43,20 @@ export default class PlaylistParser {
 			PlaylistDetailed,
 		)
 	}
+
+	public static parseArtistFeaturedOn(item: any): PlaylistDetailed {
+		return checkType(
+			{
+				type: "PLAYLIST",
+				playlistId: traverseString(item, "navigationEndpoint", "browseId")(),
+				name: traverseString(item, "runs", "text")(),
+				artist: {
+					artistId: traverseString(item, "browseId")(),
+					name: traverseString(item, "runs", "text")(-3),
+				},
+				thumbnails: traverseList(item, "thumbnails"),
+			},
+			PlaylistDetailed,
+		)
+	}
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -107,6 +107,8 @@ export const ArtistFull = z.object({
 	topAlbums: z.array(AlbumDetailed),
 	topSingles: z.array(AlbumDetailed),
 	topVideos: z.array(VideoDetailed.omit({ duration: true })),
+    featuredOn: z.array(PlaylistDetailed),
+    similarArtists: z.array(ArtistDetailed),
 })
 
 export type AlbumFull = z.infer<typeof AlbumFull>


### PR DESCRIPTION
I noticed the artist page parser was missing 2 sections.
![image](https://github.com/zS1L3NT/ts-npm-ytmusic-api/assets/16338638/ca37ce2d-61e1-44b2-9000-419977f76868)
