### PR TITLE
Fixed null duration when parsing playlist videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YTMusic API
 
+This is my version of ts-npm-ytmusic-api with bugs fixed. The original work can be found [here](https://github.com/zS1L3NT/ts-npm-ytmusic-api?tab=readme-ov-file).
+
 ![License](https://img.shields.io/github/license/zS1L3NT/ts-npm-ytmusic-api?style=for-the-badge) ![Languages](https://img.shields.io/github/languages/count/zS1L3NT/ts-npm-ytmusic-api?style=for-the-badge) ![Top Language](https://img.shields.io/github/languages/top/zS1L3NT/ts-npm-ytmusic-api?style=for-the-badge) ![Commit Activity](https://img.shields.io/github/commit-activity/y/zS1L3NT/ts-npm-ytmusic-api?style=for-the-badge) ![Last commit](https://img.shields.io/github/last-commit/zS1L3NT/ts-npm-ytmusic-api?style=for-the-badge)
 
 YouTube Music API (Unofficial) is a YouTube Music data scraper. It comes with TypeScript support API for return types. The NPM package can be found [here](https://npmjs.com/package/ytmusic-api)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "@mirantee/ytmusic-api",
-	"version": "5.2.3",
+	"name": "ytmusic-api",
+	"version": "5.2.2",
 	"description": "YouTube Music API",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -11,10 +11,7 @@
 		"type": "git",
 		"url": "https://github.com/zS1L3NT/ts-npm-ytmusic-api"
 	},
-	"files": [
-		"dist",
-		"package.json"
-	],
+	"files": ["dist", "package.json"],
 	"exports": {
 		".": {
 			"require": "./dist/index.js",
@@ -39,9 +36,5 @@
 		"typescript": "5.1",
 		"zod-to-json-schema": "^3.23.1"
 	},
-	"keywords": [
-		"youtube",
-		"music",
-		"api"
-	]
+	"keywords": ["youtube", "music", "api"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mirantee/ytmusic-api",
-	"version": "5.2.3",
+	"version": "5.2.4",
 	"description": "YouTube Music API",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -9,7 +9,7 @@
 	"license": "GPL-3.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/zS1L3NT/ts-npm-ytmusic-api"
+		"url": "https://github.com/Miran-Mirantee/ts-npm-ytmusic-api"
 	},
 	"files": ["dist", "package.json"],
 	"exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "ytmusic-api",
-	"version": "5.2.2",
+	"name": "@mirantee/ytmusic-api",
+	"version": "5.2.3",
 	"description": "YouTube Music API",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "ytmusic-api",
-	"version": "5.2.2",
+	"name": "@mirantee/ytmusic-api",
+	"version": "5.2.3",
 	"description": "YouTube Music API",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -11,7 +11,10 @@
 		"type": "git",
 		"url": "https://github.com/zS1L3NT/ts-npm-ytmusic-api"
 	},
-	"files": ["dist", "package.json"],
+	"files": [
+		"dist",
+		"package.json"
+	],
 	"exports": {
 		".": {
 			"require": "./dist/index.js",
@@ -36,5 +39,9 @@
 		"typescript": "5.1",
 		"zod-to-json-schema": "^3.23.1"
 	},
-	"keywords": ["youtube", "music", "api"]
+	"keywords": [
+		"youtube",
+		"music",
+		"api"
+	]
 }

--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -499,7 +499,10 @@ export default class YTMusic {
 			"musicResponsiveListItemRenderer",
 		)
 		let continuation = traverse(playlistData, "continuation")
-		continuation = continuation[0]
+		// Sometimes it returns array, dunno why
+		if (continuation instanceof Array) {
+			continuation = continuation[0]
+		}
 
 		while (!(continuation instanceof Array)) {
 			const songsData = await this.constructRequest("browse", {}, { continuation })
@@ -507,7 +510,7 @@ export default class YTMusic {
 			continuation = traverse(songsData, "continuation")
 		}
 
-		return songs.map(VideoParser.parsePlaylistVideo)
+		return songs.map(VideoParser.parsePlaylistVideo).filter((video): video is VideoDetailed => video !== undefined)
 	}
 
 	/**

--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -499,6 +499,8 @@ export default class YTMusic {
 			"musicResponsiveListItemRenderer",
 		)
 		let continuation = traverse(playlistData, "continuation")
+		continuation = continuation[0]
+
 		while (!(continuation instanceof Array)) {
 			const songsData = await this.constructRequest("browse", {}, { continuation })
 			songs.push(...traverseList(songsData, "musicResponsiveListItemRenderer"))

--- a/src/parsers/VideoParser.ts
+++ b/src/parsers/VideoParser.ts
@@ -54,22 +54,25 @@ export default class VideoParser {
 		}
 	}
 
-	public static parsePlaylistVideo(item: any): VideoDetailed {
+	public static parsePlaylistVideo(item: any): VideoDetailed | undefined {
 		const flexColumns = traverseList(item, "flexColumns", "runs").flat()
 		const fixedcolumns = traverseList(item, "fixedColumns", "runs").flat()
 
 		const title = flexColumns.find(isTitle) || flexColumns[0]
 		const artist = flexColumns.find(isArtist) || flexColumns[1]
 		const duration = fixedcolumns.find(isDuration)
-		
+
+		const videoId1: string = traverseString(item, "playNavigationEndpoint", "videoId")
+		const videoId2: string[] = traverseList(item, "thumbnails")[0].url.match(/https:\/\/i\.ytimg\.com\/vi\/(.+)\//,)
+
+		if (videoId1 == '' && videoId2 == null) {
+			return
+		}
+
 		return checkType(
 			{
 				type: "VIDEO",
-				videoId:
-					traverseString(item, "playNavigationEndpoint", "videoId") ||
-					traverseList(item, "thumbnails")[0].url.match(
-						/https:\/\/i\.ytimg\.com\/vi\/(.+)\//,
-					)[1],
+				videoId: videoId1 || videoId2[1] as string,
 				name: traverseString(title, "text"),
 				artist: {
 					name: traverseString(artist, "text"),

--- a/src/parsers/VideoParser.ts
+++ b/src/parsers/VideoParser.ts
@@ -55,12 +55,13 @@ export default class VideoParser {
 	}
 
 	public static parsePlaylistVideo(item: any): VideoDetailed {
-		const columns = traverseList(item, "flexColumns", "runs").flat()
+		const flexColumns = traverseList(item, "flexColumns", "runs").flat()
+		const fixedcolumns = traverseList(item, "fixedColumns", "runs").flat()
 
-		const title = columns.find(isTitle) || columns[0]
-		const artist = columns.find(isArtist) || columns[1]
-		const duration = columns.find(isDuration)
-
+		const title = flexColumns.find(isTitle) || flexColumns[0]
+		const artist = flexColumns.find(isArtist) || flexColumns[1]
+		const duration = fixedcolumns.find(isDuration)
+		
 		return checkType(
 			{
 				type: "VIDEO",


### PR DESCRIPTION
I noticed that when getting playlist videos, the duration of each video is null.
So I checked the parsePlaylistVideo() and found that the retrieved columns don't have duration of video.