### PR TITLE
fix: filter out `undefined` values from query parameters in `constructRequest` leading to 400s

### DIFF
--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -158,7 +158,9 @@ export default class YTMusic {
 		}
 
 		const searchParams = new URLSearchParams({
-			...query,
+			...Object.fromEntries(
+        Object.entries(query).filter(([, value]) => value !== undefined)
+      ),
 			alt: "json",
 			key: this.config.INNERTUBE_API_KEY!,
 		})


### PR DESCRIPTION
Noticed the `/browse` endpoint was broken when fetching playlist details via `getPlaylistVideos`, resulting in an Axios 400 Bad Request error. This fix filters out undefined query parameters in `constructRequest` to prevent invalid requests (e.g., `continuation=undefined`).  
- Updated `searchParams` in `constructRequest` to exclude undefined values using `Object.fromEntries` and `filter`.  
- Tested with playlist IDs to confirm the 400 error is resolved and videos load correctly.

> Note: some tests are failing, but they were failing upon pull and first install. I thought it would being the scope of this PR to attempt and fix those too.