### PR TITLE
feat: get timestamp lyrics, context private getter

### DIFF
--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -439,7 +439,7 @@ export default class YTMusic {
 		const lyricsData = await this.constructRequest("browse", { browseId, context: modified_ctx })
 		const lyrics = traverseList(lyricsData, "timedLyricsModel", "lyricsData", "timedLyricsData")
 		
-		return lyrics
+		return lyrics.length
 			? lyrics
 				.map(({ lyricLine, cueRange: { startTimeMilliseconds, endTimeMilliseconds, metadata: { id } } }) => {
 					return {

--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from "axios"
 import { Cookie, CookieJar } from "tough-cookie"
 
-import { FE_MUSIC_HOME } from "./constants"
+import { ANDROID_CLIENT_NAME, ANDROID_CLIENT_VERSION, FE_MUSIC_HOME } from "./constants"
 import AlbumParser from "./parsers/AlbumParser"
 import ArtistParser from "./parsers/ArtistParser"
 import Parser from "./parsers/Parser"
@@ -434,8 +434,8 @@ export default class YTMusic {
 		const browseId = traverse(traverseList(data, "tabs", "tabRenderer")[1], "browseId")
 
 		const modified_ctx = this.context
-		modified_ctx.client.clientName = "ANDROID_MUSIC"
-		modified_ctx.client.clientVersion = "7.21.50"
+		modified_ctx.client.clientName = ANDROID_CLIENT_NAME
+		modified_ctx.client.clientVersion = ANDROID_CLIENT_VERSION
 		const lyricsData = await this.constructRequest("browse", { browseId, context: modified_ctx })
 		const lyrics = traverseList(lyricsData, "timedLyricsModel", "lyricsData", "timedLyricsData")
 		

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,5 @@ export enum PageType {
 }
 
 export const FE_MUSIC_HOME = "FEmusic_home"
+export const ANDROID_CLIENT_NAME = "ANDROID_MUSIC"
+export const ANDROID_CLIENT_VERSION = "7.21.50"

--- a/src/tests/core.spec.ts
+++ b/src/tests/core.spec.ts
@@ -86,7 +86,6 @@ queries.forEach(query => {
 		it("Get timed lyrics of the first song result", async () => {
 			const songs = await ytmusic.searchSongs(query)
 			const lyrics = await ytmusic.getTimedLyrics(songs[0]!.videoId)
-			console.log(lyrics)
 			expect(lyrics, z.nullable(z.array(TimedLyric)))
 		})
 

--- a/src/tests/core.spec.ts
+++ b/src/tests/core.spec.ts
@@ -14,6 +14,7 @@ import {
 	SearchResult,
 	SongDetailed,
 	SongFull,
+	TimedLyric,
 	VideoDetailed,
 	VideoFull,
 } from "../types"
@@ -80,6 +81,13 @@ queries.forEach(query => {
 			const songs = await ytmusic.searchSongs(query)
 			const lyrics = await ytmusic.getLyrics(songs[0]!.videoId)
 			expect(lyrics, z.nullable(z.array(z.string())))
+		})
+
+		it("Get timed lyrics of the first song result", async () => {
+			const songs = await ytmusic.searchSongs(query)
+			const lyrics = await ytmusic.getTimedLyrics(songs[0]!.videoId)
+			console.log(lyrics)
+			expect(lyrics, z.nullable(z.array(TimedLyric)))
 		})
 
 		it("Get details of the first song result", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,7 +125,17 @@ export const UpNextsDetails = z
 		thumbnails: z.array(ThumbnailFull),
 		})
 		.strict()
-		
+
+export type TimedLyric = z.infer<typeof TimedLyric>
+export const TimedLyric = z
+	.object({
+		text: z.string(),
+		start_time: z.number(),
+		end_time: z.number(),
+		id: z.number()
+	})
+	.strict()
+
 export type ArtistFull = z.infer<typeof ArtistFull>
 export const ArtistFull = z
 	.object({


### PR DESCRIPTION
> [!IMPORTANT]
> Literally made this before knowing #50 existed. Technically, does the same, but I don't know why #50 stopped working.
> This version was tested and passed the `bun test`.

```JS
await ytmusic.getTimedLyrics('videoId');
```
Return format is inspired by the one from [ytmusicapi](https://github.com/sigma67/ytmusicapi)
<img width="382" height="748" alt="imagen" src="https://github.com/user-attachments/assets/3a3d91cc-6f8c-46e7-ac84-a2a9b3a88eca" />

### Added

- `getTimedLyrics` method
- `context` private getter

### Changed

- `constructRequest` uses `this.context`