### PR TITLE
Fix YouTube Music config gathering

### DIFF
--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -96,10 +96,10 @@ export default class YTMusic {
 		}
 
 		const html = (await this.client.get("/")).data as string
-		const setConfigs = html.match(/ytcfg\.set\(.*\)/) || []
+		const setConfigs = html.match(/ytcfg\.set\(.*?\);/) || []
 
 		const configs = setConfigs
-			.map(c => c.slice(10, -1))
+			.map(c => c.slice(10, -2))
 			.map(s => {
 				try {
 					return JSON.parse(s)


### PR DESCRIPTION
Currently, I am maintaining a project that uses this library as a dependency. Today, the API broke. After investigating, I found that the regex was capturing excessive data, which caused the JSON parser to fail. This fix updates the regex pattern, resolving the initialization issue.