### PR TITLE
feat: add higher resolution thumbnail to results

### DIFF
--- a/src/utils/getHighresThumbnail.ts
+++ b/src/utils/getHighresThumbnail.ts
@@ -1,0 +1,66 @@
+import type { ThumbnailFull } from "../types"
+
+/**
+ * Generates the highest resolution thumbnail for a given list of thumbnails.
+ * @param thumbnails Must be thumbnails from the same content for the expected result.
+ * @returns The highest resolution thumbnail or null if existing thumbnail has greater resolution.
+ */
+export default function (thumbnails: ThumbnailFull[]): ThumbnailFull | null {
+    // Known hosts, used to parse original thumb link to highres version
+    type hosts =
+        | "lh3.googleusercontent.com"
+        | "i.ytimg.com"
+        | "yt3.googleusercontent.com"
+
+    // The highest resolution thumbnail given in the item
+    let highestOriginalThumb: ThumbnailFull = thumbnails.reduce((prev, curr) =>
+        curr.width > prev.width ? curr : prev,
+    )
+    let url: string = highestOriginalThumb.url
+
+    // Get the host, widht and height of the highest original thumbnail
+    let host: hosts = new URL(highestOriginalThumb.url).host as hosts
+    let width: number = highestOriginalThumb.width
+    let height: number = highestOriginalThumb.height
+
+    switch (host) {
+        case "lh3.googleusercontent.com":
+            // Replaces the width param with the highest resolution yt provides, removes other optional params
+            width = 1200
+            height = width
+            url = url.split("=w")[0]! + `=w${width}`
+            // Expected original url: https://lh3.googleusercontent.com/<some data>=w<original width>-h<original height>-p-l90-rj
+            // Example of new url: https://lh3.googleusercontent.com/<some data>=w<max width>
+            break
+
+        case "yt3.googleusercontent.com":
+            // Replaces the scale param with the highest resolution yt provides using width param, removes other optional params
+            width = 1200
+            height = width
+            url = url.split("=s")[0]! + `=w${width}`
+            // Expected original url: https://yt3.googleusercontent.com/<some data>=s<original width>
+            // Example of new url: https://yt3.googleusercontent.com/<some data>=w<max width>
+            break
+
+        case "i.ytimg.com":
+            // Changes sddefault.jpeg to maxresdefault.jpeg (best quality yt provides), remove optional params
+            width = 1280
+            height = 720
+            url = url.replace("sddefault", "maxresdefault")
+            url = url.includes("?") ? url.split("?")[0]! : url
+            // Expected original url: https://i.ytimg.com/vi/<some data>/sddefault.jpg?sqp=<some data>
+            // Example of new url: https://i.ytimg.com/vi/<some data>/maxresdefault.jpg
+            break
+
+        default:
+            // Unknown host => do nothing
+            // You can log the host to the console and, if possible, add a case for extracting a higher resolution thumbnail from it.
+            // console.log(`DEBUG: Unknown host: '${host}'`)
+            break
+    }
+
+    const ifBetterQuality: boolean =
+        width * height >
+        highestOriginalThumb.width * highestOriginalThumb.height
+    return ifBetterQuality ? { url: url, width: width, height: height } : null
+}

--- a/src/utils/getHighresThumbnail.ts
+++ b/src/utils/getHighresThumbnail.ts
@@ -10,47 +10,41 @@ export default function getHighresThumbnail(
 ): ThumbnailFull | null {
     if (thumbnails.length === 0) return null
 
-    // The highest resolution thumbnail given in the item
+    // Get the highest resolution thumbnail given in the list
     const highestOriginalThumb: ThumbnailFull = thumbnails.reduce(
         (prev, curr) =>
             curr.width * curr.height > prev.width * prev.height ? curr : prev,
     )
 
     let url: string = highestOriginalThumb.url
-
-    // Get the host, width and height of the highest original thumbnail
-    const host: string = new URL(highestOriginalThumb.url).host
     let width: number = highestOriginalThumb.width
     let height: number = highestOriginalThumb.height
+    const host: string = new URL(url).host
 
     switch (host) {
         case "lh3.googleusercontent.com":
-            // Replaces the width param with the highest resolution yt provides, removes other optional params
+            // Expected original url: https://lh3.googleusercontent.com/<some data>=w<original width>-h<original height>-p-l90-rj
+            // Example of new url: https://lh3.googleusercontent.com/<some data>=w<max width>
             width = 1200
             height = width
             url = url.split("=w")[0] + `=w${width}`
-            // Expected original url: https://lh3.googleusercontent.com/<some data>=w<original width>-h<original height>-p-l90-rj
-            // Example of new url: https://lh3.googleusercontent.com/<some data>=w<max width>
             break
 
         case "yt3.googleusercontent.com":
-            // Replaces the scale param with the highest resolution yt provides using width param, removes other optional params
+            // Expected original url: https://yt3.googleusercontent.com/<some data>=s<original width>
+            // Example of new url: https://yt3.googleusercontent.com/<some data>=w<max width>
             width = 1200
             height = width
             url = url.split("=s")[0] + `=w${width}`
-            // Expected original url: https://yt3.googleusercontent.com/<some data>=s<original width>
-            // Example of new url: https://yt3.googleusercontent.com/<some data>=w<max width>
             break
 
         case "i.ytimg.com":
-            // Changes sddefault.jpeg to maxresdefault.jpeg (best quality yt provides), remove optional params
+            // Expected original url: https://i.ytimg.com/vi/<some data>/sddefault.jpg?sqp=<some data>
+            // Example of new url: https://i.ytimg.com/vi/<some data>/maxresdefault.jpg
             width = 1280
             height = 720
             url = url.replace("sddefault", "maxresdefault")
             url = url.includes("?") ? url.split("?")[0]! : url
-
-            // Expected original url: https://i.ytimg.com/vi/<some data>/sddefault.jpg?sqp=<some data>
-            // Example of new url: https://i.ytimg.com/vi/<some data>/maxresdefault.jpg
             break
 
         default:

--- a/src/utils/getHighresThumbnail.ts
+++ b/src/utils/getHighresThumbnail.ts
@@ -1,25 +1,25 @@
-import type { ThumbnailFull } from "../types"
+import { ThumbnailFull } from "../types"
 
 /**
  * Generates the highest resolution thumbnail for a given list of thumbnails.
  * @param thumbnails Must be thumbnails from the same content for the expected result.
  * @returns The highest resolution thumbnail or null if existing thumbnail has greater resolution.
  */
-export default function (thumbnails: ThumbnailFull[]): ThumbnailFull | null {
-    // Known hosts, used to parse original thumb link to highres version
-    type hosts =
-        | "lh3.googleusercontent.com"
-        | "i.ytimg.com"
-        | "yt3.googleusercontent.com"
+export default function getHighresThumbnail(
+    thumbnails: ThumbnailFull[],
+): ThumbnailFull | null {
+    if (thumbnails.length === 0) return null
 
     // The highest resolution thumbnail given in the item
-    let highestOriginalThumb: ThumbnailFull = thumbnails.reduce((prev, curr) =>
-        curr.width > prev.width ? curr : prev,
+    const highestOriginalThumb: ThumbnailFull = thumbnails.reduce(
+        (prev, curr) =>
+            curr.width * curr.height > prev.width * prev.height ? curr : prev,
     )
+
     let url: string = highestOriginalThumb.url
 
-    // Get the host, widht and height of the highest original thumbnail
-    let host: hosts = new URL(highestOriginalThumb.url).host as hosts
+    // Get the host, width and height of the highest original thumbnail
+    const host: string = new URL(highestOriginalThumb.url).host
     let width: number = highestOriginalThumb.width
     let height: number = highestOriginalThumb.height
 
@@ -28,7 +28,7 @@ export default function (thumbnails: ThumbnailFull[]): ThumbnailFull | null {
             // Replaces the width param with the highest resolution yt provides, removes other optional params
             width = 1200
             height = width
-            url = url.split("=w")[0]! + `=w${width}`
+            url = url.split("=w")[0] + `=w${width}`
             // Expected original url: https://lh3.googleusercontent.com/<some data>=w<original width>-h<original height>-p-l90-rj
             // Example of new url: https://lh3.googleusercontent.com/<some data>=w<max width>
             break
@@ -37,7 +37,7 @@ export default function (thumbnails: ThumbnailFull[]): ThumbnailFull | null {
             // Replaces the scale param with the highest resolution yt provides using width param, removes other optional params
             width = 1200
             height = width
-            url = url.split("=s")[0]! + `=w${width}`
+            url = url.split("=s")[0] + `=w${width}`
             // Expected original url: https://yt3.googleusercontent.com/<some data>=s<original width>
             // Example of new url: https://yt3.googleusercontent.com/<some data>=w<max width>
             break
@@ -48,6 +48,7 @@ export default function (thumbnails: ThumbnailFull[]): ThumbnailFull | null {
             height = 720
             url = url.replace("sddefault", "maxresdefault")
             url = url.includes("?") ? url.split("?")[0]! : url
+
             // Expected original url: https://i.ytimg.com/vi/<some data>/sddefault.jpg?sqp=<some data>
             // Example of new url: https://i.ytimg.com/vi/<some data>/maxresdefault.jpg
             break
@@ -56,7 +57,7 @@ export default function (thumbnails: ThumbnailFull[]): ThumbnailFull | null {
             // Unknown host => do nothing
             // You can log the host to the console and, if possible, add a case for extracting a higher resolution thumbnail from it.
             // console.log(`DEBUG: Unknown host: '${host}'`)
-            break
+            return null
     }
 
     const ifBetterQuality: boolean =

--- a/src/utils/traverse.ts
+++ b/src/utils/traverse.ts
@@ -1,38 +1,49 @@
+import getHighresThumbnail from "./getHighresThumbnail"
+
 export const traverse = (data: any, ...keys: string[]) => {
-	const again = (data: any, key: string, deadEnd = false): any => {
-		const res = []
+    const again = (data: any, key: string, deadEnd = false): any => {
+        const res = []
 
-		if (data instanceof Object && key in data) {
-			res.push(data[key])
-			if (deadEnd) return res.length === 1 ? res[0] : res
-		}
+        if (data instanceof Object && key in data) {
+            res.push(data[key])
+            if (deadEnd) return res.length === 1 ? res[0] : res
+        }
 
-		if (data instanceof Array) {
-			res.push(...data.map(v => again(v, key)).flat())
-		} else if (data instanceof Object) {
-			res.push(
-				...Object.keys(data)
-					.map(k => again(data[k], key))
-					.flat(),
-			)
-		}
+        if (data instanceof Array) {
+            res.push(...data.map((v) => again(v, key)).flat())
+        } else if (data instanceof Object) {
+            res.push(
+                ...Object.keys(data)
+                    .map((k) => again(data[k], key))
+                    .flat(),
+            )
+        }
 
-		return res.length === 1 ? res[0] : res
-	}
+        return res.length === 1 ? res[0] : res
+    }
 
-	let value = data
-	const lastKey = keys.at(-1)
-	for (const key of keys) {
-		value = again(value, key, lastKey === key)
-	}
+    let value = data
+    const lastKey = keys.at(-1)
+    for (const key of keys) {
+        value = again(value, key, lastKey === key)
+    }
+    if (lastKey == "thumbnails") {
+        try {
+            const highresThumbnail = getHighresThumbnail(value)
+            if (highresThumbnail != null) value.push(highresThumbnail)
+        } catch (error) {
+            // Something went wrong pushing the highres thumbnail
+            // console.error(error)
+        }
+    }
 
-	return value
+    return value
 }
 
 export const traverseList = (data: any, ...keys: string[]): any[] => {
-	return [traverse(data, ...keys)].flat()
+    return [traverse(data, ...keys)].flat()
 }
 
 export const traverseString = (data: any, ...keys: string[]): string => {
-	return traverseList(data, ...keys).at(0) || ""
+    return traverseList(data, ...keys).at(0) || ""
 }

--- a/src/utils/traverse.ts
+++ b/src/utils/traverse.ts
@@ -27,7 +27,7 @@ export const traverse = (data: any, ...keys: string[]) => {
     for (const key of keys) {
         value = again(value, key, lastKey === key)
     }
-    if (lastKey == "thumbnails") {
+    if (lastKey === "thumbnails") {
         try {
             value = Array.isArray(value) ? value : [value]
             const highresThumbnail = getHighresThumbnail(value)

--- a/src/utils/traverse.ts
+++ b/src/utils/traverse.ts
@@ -29,7 +29,6 @@ export const traverse = (data: any, ...keys: string[]) => {
     }
     if (lastKey == "thumbnails") {
         try {
-            // Normalize value to an array
             value = Array.isArray(value) ? value : [value]
             const highresThumbnail = getHighresThumbnail(value)
             if (highresThumbnail != null) value.push(highresThumbnail)

--- a/src/utils/traverse.ts
+++ b/src/utils/traverse.ts
@@ -29,11 +29,12 @@ export const traverse = (data: any, ...keys: string[]) => {
     }
     if (lastKey == "thumbnails") {
         try {
+            // Normalize value to an array
+            value = Array.isArray(value) ? value : [value]
             const highresThumbnail = getHighresThumbnail(value)
             if (highresThumbnail != null) value.push(highresThumbnail)
         } catch (error) {
-            // Something went wrong pushing the highres thumbnail
-            // console.error(error)
+            console.error(error)
         }
     }
 

--- a/src/utils/traverse.ts
+++ b/src/utils/traverse.ts
@@ -31,7 +31,7 @@ export const traverse = (data: any, ...keys: string[]) => {
         try {
             value = Array.isArray(value) ? value : [value]
             const highresThumbnail = getHighresThumbnail(value)
-            if (highresThumbnail != null) value.push(highresThumbnail)
+            if (highresThumbnail !== null) value.push(highresThumbnail)
         } catch (error) {
             console.error(error)
         }


### PR DESCRIPTION
I noticed that the provided thumbnails in the results didn't include the highest quality version, so I added a utility that parses these thumbnails and generates the highest resolution version for that thumbnail URL.

I implemented this utility to append the highest resolution thumbnail version to the list of thumbnails for a result.

> This is my first pull request, if something could use improvement please let me know.